### PR TITLE
Max. page size for the single reguest isn't 200?

### DIFF
--- a/scripts/01 - api request.R
+++ b/scripts/01 - api request.R
@@ -29,7 +29,7 @@ endpoint <- "https://content.guardianapis.com/search"
 parameters <- list(q = "amazon",
                    from_date = "2000-01-01",
                    to_date = "2022-12-31",
-                   page_size = 5000)
+                   page_size = 200)
 
 # Send GET request to API and retrieve response
 response <- GET(endpoint, query = c(parameters, list(apiKey = api_key)))


### PR DESCRIPTION
My action here is simply for practice. But perhaps a useful note after all: According to the Guardian API documentation, the page size accepted by default is 50 and the maximum page size for the single reguest is 200. The documentation points out that larger page sizes can result in slower response times, and it is generally recommended to use smaller page sizes for better performance. 