### PR TITLE
Changed the page size to 50

### DIFF
--- a/scripts/01 - api request.R
+++ b/scripts/01 - api request.R
@@ -26,10 +26,12 @@ api_key <- rstudioapi::askForPassword()
 endpoint <- "https://content.guardianapis.com/search"
 
 # Set query parameters
+# According to Guardian documentation the limit for page size is 50: 
+# https://open-platform.theguardian.com/documentation/search
 parameters <- list(q = "amazon",
                    from_date = "2000-01-01",
                    to_date = "2022-12-31",
-                   page_size = 5000)
+                   page_size = 50)
 
 # Send GET request to API and retrieve response
 response <- GET(endpoint, query = c(parameters, list(apiKey = api_key)))


### PR DESCRIPTION
My action here is simply for practice. But perhaps a useful note after all: According to the Guardian API documentation, the accepted page size is 1-50. The documentation points out that larger page sizes can result in slower response times, and it is generally recommended to use smaller page sizes for better performance. 